### PR TITLE
Fix Deprecation Warning of using async function with callback fs.write

### DIFF
--- a/lib/plugins/history.js
+++ b/lib/plugins/history.js
@@ -65,7 +65,7 @@ module.exports = function(settings) {
       var buffer;
       if (this.history.length) {
         buffer = new Buffer(JSON.stringify(this.history));
-        fs.write(stream.fd, buffer, 0, buffer.length, 0);
+        fs.writeSync(stream.fd, buffer, 0, buffer.length, 0);
       }
       return parent.apply(this, arguments);
     };

--- a/src/plugins/history.coffee
+++ b/src/plugins/history.coffee
@@ -41,7 +41,7 @@ module.exports = (settings) ->
   Interface.prototype._addHistory = ((parent) -> ->
     if @history.length
       buffer = new Buffer JSON.stringify( @history )
-      fs.write stream.fd, buffer, 0, buffer.length, 0
+      fs.writeSync stream.fd, buffer, 0, buffer.length, 0
     parent.apply @, arguments
   ) Interface.prototype._addHistory
   null


### PR DESCRIPTION
Fixes #18.
Change fs.write to fs.writeSync.
New to CoffeeScript. Not sure if you can just update both of these files directly or if there is a rebuild command.